### PR TITLE
classifiers: icmp classifier fix

### DIFF
--- a/classifiers/icmp.go
+++ b/classifiers/icmp.go
@@ -14,19 +14,17 @@ func (_ IcmpClassifier) HeuristicClassify(flow *godpi.Flow) bool {
 	for _, packet := range flow.Packets {
 		if layer := (*packet).Layer(layers.LayerTypeIPv4); layer != nil {
 			ipLayer := layer.(*layers.IPv4)
-			if ipLayer.Protocol == layers.IPProtocolIPv4 {
+			if ipLayer.Protocol == layers.IPProtocolICMPv4 {
 				return true
 			}
 		} else if layer := (*packet).Layer(layers.LayerTypeIPv6); layer != nil {
 			ipLayer := layer.(*layers.IPv6)
-			if ipLayer.NextHeader == layers.IPProtocolIPv6 {
+			if ipLayer.NextHeader == layers.IPProtocolICMPv6 {
 				return true
 			}
-		} else {
-			return false
 		}
 	}
-	return true
+	return false
 }
 
 func (_ IcmpClassifier) GetProtocol() godpi.Protocol {


### PR DESCRIPTION
* Fixes ICMP classifier incorrectly classifying packets. (closes #21)

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>