### PR TITLE
project structure: refactor types and utils into new packages

### DIFF
--- a/.travis.golint.sh
+++ b/.travis.golint.sh
@@ -3,10 +3,11 @@
 cd "$(dirname $0)"
 
 go get github.com/golang/lint/golint
-DIRS=". godpi_example"
 # Add subdirectories here as we clean up golint on each.
-for subdir in $DIRS; do
-  if [[ $(golint $subdir) != '' ]]; then
+for subdir in $GO_DIRS; do
+  res=$(golint $subdir)
+  if [[ $res != '' ]]; then
+      echo "$res"
       exit 1
   fi
 done

--- a/.travis.govet.sh
+++ b/.travis.govet.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd "$(dirname $0)"
+set -e
+for subdir in $GO_DIRS; do
+  pushd $subdir
+  go vet
+  popd
+done

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,16 @@ dist: trusty
 sudo: required
 services:
     - docker
+env:
+    - GO_DIRS=". ./classifiers ./wrappers ./types ./utils ./godpi_example"
 script:
     - sudo docker build -t godpi-example .
     - >
         sudo docker run --entrypoint=/bin/bash
         -e TRAVIS
         -e TRAVIS_JOB_ID
+        -e GO_DIRS
         godpi-example -c 'go get golang.org/x/tools/cmd/cover github.com/mattn/goveralls &&
         $GOPATH/bin/goveralls -ignore godpi_example/example_app.go -service=travis-ci'
+    - ./.travis.golint.sh
+    - ./.travis.govet.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR $GOPATH/src/github.com/mushorg/go-dpi
 ADD . .
 RUN glide install && \
     glide update && \
-    go test . ./classifiers ./wrappers && \
+    echo $GO_DIRS | xargs go test && \
     go install ./godpi_example
 
 ENTRYPOINT ["godpi_example"]

--- a/classifiers/classifiers.go
+++ b/classifiers/classifiers.go
@@ -4,7 +4,7 @@ package classifiers
 
 import (
 	"github.com/google/gopacket"
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 )
 
 // GoDPIName is the name of the library, to be used as an identifier for the
@@ -15,7 +15,7 @@ const GoDPIName = "go-dpi"
 // that returns the classifier's detected protocol.
 type GenericClassifier interface {
 	// GetProtocol returns the protocol this classifier can detect.
-	GetProtocol() godpi.Protocol
+	GetProtocol() types.Protocol
 }
 
 // HeuristicClassifier is implemented by the classifiers that have heuristic
@@ -23,7 +23,7 @@ type GenericClassifier interface {
 type HeuristicClassifier interface {
 	// HeuristicClassify returns whether this classifier can identify the flow
 	// using heuristics.
-	HeuristicClassify(*godpi.Flow) bool
+	HeuristicClassify(*types.Flow) bool
 }
 
 var classifierList = [...]GenericClassifier{
@@ -42,7 +42,7 @@ var classifierList = [...]GenericClassifier{
 
 // ClassifyFlow applies all the classifiers to a flow and returns the protocol
 // that is detected by a classifier if there is one. Otherwise, it returns nil.
-func ClassifyFlow(flow *godpi.Flow) (result godpi.Protocol, source godpi.ClassificationSource) {
+func ClassifyFlow(flow *types.Flow) (result types.Protocol, source types.ClassificationSource) {
 	for _, classifier := range classifierList {
 		if heuristic, ok := classifier.(HeuristicClassifier); ok {
 			if heuristic.HeuristicClassify(flow) {
@@ -60,7 +60,7 @@ func ClassifyFlow(flow *godpi.Flow) (result godpi.Protocol, source godpi.Classif
 // checkFlowLayer applies the check function to the specified layer of each
 // packet in a flow, where it is available. It returns whether there is a
 // packet in the flow for which the check function returns true.
-func checkFlowLayer(flow *godpi.Flow, layerType gopacket.LayerType,
+func checkFlowLayer(flow *types.Flow, layerType gopacket.LayerType,
 	checkFunc func(layer gopacket.Layer) bool) bool {
 	for _, packet := range flow.Packets {
 		if layer := (*packet).Layer(layerType); layer != nil {

--- a/classifiers/classifiers_test.go
+++ b/classifiers/classifiers_test.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
+	"github.com/mushorg/go-dpi/utils"
 	"strings"
 )
 
 func TestClassifyFlow(t *testing.T) {
-	dumpPackets, err := godpi.ReadDumpFile("../godpi_example/dumps/http.cap")
+	dumpPackets, err := utils.ReadDumpFile("../godpi_example/dumps/http.cap")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -18,9 +19,9 @@ func TestClassifyFlow(t *testing.T) {
 		<-dumpPackets
 	}
 	packet := <-dumpPackets
-	flow := godpi.CreateFlowFromPacket(&packet)
+	flow := types.CreateFlowFromPacket(&packet)
 	protocol, source := ClassifyFlow(flow)
-	if protocol != godpi.HTTP || flow.DetectedProtocol != godpi.HTTP {
+	if protocol != types.HTTP || flow.DetectedProtocol != types.HTTP {
 		t.Error("Wrong protocol detected:", protocol)
 	}
 	if name := flow.ClassificationSource; name != GoDPIName || source != GoDPIName {
@@ -29,19 +30,19 @@ func TestClassifyFlow(t *testing.T) {
 }
 
 func TestClassifyFlowEmpty(t *testing.T) {
-	flow := godpi.NewFlow()
+	flow := types.NewFlow()
 	protocol, source := ClassifyFlow(flow)
-	if protocol != godpi.Unknown || source != godpi.NoSource {
+	if protocol != types.Unknown || source != types.NoSource {
 		t.Error("Protocol incorrectly detected:", protocol)
 	}
 }
 
 func TestCheckFlowLayer(t *testing.T) {
-	dumpPackets, err := godpi.ReadDumpFile("../godpi_example/dumps/http.cap")
+	dumpPackets, err := utils.ReadDumpFile("../godpi_example/dumps/http.cap")
 	if err != nil {
 		t.Fatal(err)
 	}
-	flow := godpi.NewFlow()
+	flow := types.NewFlow()
 	for packet := range dumpPackets {
 		packetCopy := packet
 		flow.AddPacket(&packetCopy)
@@ -68,11 +69,11 @@ func TestCheckFlowLayer(t *testing.T) {
 }
 
 func TestCheckFirstPayload(t *testing.T) {
-	dumpPackets, err := godpi.ReadDumpFile("../godpi_example/dumps/http.cap")
+	dumpPackets, err := utils.ReadDumpFile("../godpi_example/dumps/http.cap")
 	if err != nil {
 		t.Fatal(err)
 	}
-	flow := godpi.NewFlow()
+	flow := types.NewFlow()
 	for packet := range dumpPackets {
 		packetCopy := packet
 		flow.AddPacket(&packetCopy)
@@ -101,15 +102,15 @@ func TestCheckFirstPayload(t *testing.T) {
 	}
 }
 
-func getPcapDumpProtoMap(filename string) (result map[godpi.Protocol]int) {
-	result = make(map[godpi.Protocol]int)
-	packets, err := godpi.ReadDumpFile(filename)
+func getPcapDumpProtoMap(filename string) (result map[types.Protocol]int) {
+	result = make(map[types.Protocol]int)
+	packets, err := utils.ReadDumpFile(filename)
 	if err != nil {
 		return
 	}
 	for packet := range packets {
-		flow, _ := godpi.GetFlowForPacket(&packet)
-		if flow.DetectedProtocol == godpi.Unknown {
+		flow, _ := types.GetFlowForPacket(&packet)
+		if flow.DetectedProtocol == types.Unknown {
 			res, _ := ClassifyFlow(flow)
 			result[res]++
 		}
@@ -118,7 +119,7 @@ func getPcapDumpProtoMap(filename string) (result map[godpi.Protocol]int) {
 }
 
 type protocolTestInfo struct {
-	protocol godpi.Protocol
+	protocol types.Protocol
 	filename string
 	count    int
 }
@@ -126,14 +127,14 @@ type protocolTestInfo struct {
 func TestClassifiers(t *testing.T) {
 	// test for each protocol the expected number of flows in the appropriate capture file
 	protocolInfos := []protocolTestInfo{
-		{godpi.HTTP, "../godpi_example/dumps/http.cap", 2},
-		{godpi.DNS, "../godpi_example/dumps/dns+icmp.pcapng", 5},
-		{godpi.ICMP, "../godpi_example/dumps/dns+icmp.pcapng", 22},
-		{godpi.ICMP, "../godpi_example/dumps/icmpv6.pcap", 49},
-		{godpi.SSL, "../godpi_example/dumps/https.cap", 1},
-		{godpi.SSH, "../godpi_example/dumps/ssh.pcap", 1},
-		{godpi.SMTP, "../godpi_example/dumps/smtp.pcap", 1},
-		{godpi.FTP, "../godpi_example/dumps/ftp.pcap", 1},
+		{types.HTTP, "../godpi_example/dumps/http.cap", 2},
+		{types.DNS, "../godpi_example/dumps/dns+icmp.pcapng", 5},
+		{types.ICMP, "../godpi_example/dumps/dns+icmp.pcapng", 22},
+		{types.ICMP, "../godpi_example/dumps/icmpv6.pcap", 49},
+		{types.SSL, "../godpi_example/dumps/https.cap", 1},
+		{types.SSH, "../godpi_example/dumps/ssh.pcap", 1},
+		{types.SMTP, "../godpi_example/dumps/smtp.pcap", 1},
+		{types.FTP, "../godpi_example/dumps/ftp.pcap", 1},
 	}
 	for _, info := range protocolInfos {
 		count := getPcapDumpProtoMap(info.filename)[info.protocol]

--- a/classifiers/dns.go
+++ b/classifiers/dns.go
@@ -3,14 +3,14 @@ package classifiers
 import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 )
 
 // DNSClassifier struct
 type DNSClassifier struct{}
 
 // HeuristicClassify for DNSClassifier
-func (_ DNSClassifier) HeuristicClassify(flow *godpi.Flow) bool {
+func (classifier DNSClassifier) HeuristicClassify(flow *types.Flow) bool {
 	return checkFlowLayer(flow, layers.LayerTypeUDP, func(layer gopacket.Layer) (detected bool) {
 		defer func() {
 			if recover() != nil {
@@ -29,6 +29,6 @@ func (_ DNSClassifier) HeuristicClassify(flow *godpi.Flow) bool {
 }
 
 // GetProtocol returns the corresponding protocol
-func (classifier DNSClassifier) GetProtocol() godpi.Protocol {
-	return godpi.DNS
+func (classifier DNSClassifier) GetProtocol() types.Protocol {
+	return types.DNS
 }

--- a/classifiers/ftp.go
+++ b/classifiers/ftp.go
@@ -3,7 +3,7 @@ package classifiers
 import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 	"strings"
 )
 
@@ -11,7 +11,7 @@ import (
 type FTPClassifier struct{}
 
 // HeuristicClassify for FTPClassifier
-func (classifier FTPClassifier) HeuristicClassify(flow *godpi.Flow) bool {
+func (classifier FTPClassifier) HeuristicClassify(flow *types.Flow) bool {
 	if len(flow.Packets) == 0 {
 		return false
 	}
@@ -33,6 +33,6 @@ func (classifier FTPClassifier) HeuristicClassify(flow *godpi.Flow) bool {
 }
 
 // GetProtocol returns the corresponding protocol
-func (classifier FTPClassifier) GetProtocol() godpi.Protocol {
-	return godpi.FTP
+func (classifier FTPClassifier) GetProtocol() types.Protocol {
+	return types.FTP
 }

--- a/classifiers/http.go
+++ b/classifiers/http.go
@@ -3,7 +3,7 @@ package classifiers
 import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 	"regexp"
 	"strings"
 )
@@ -32,7 +32,7 @@ func init() {
 }
 
 // HeuristicClassify for HTTPClassifier
-func (_ HTTPClassifier) HeuristicClassify(flow *godpi.Flow) bool {
+func (classifier HTTPClassifier) HeuristicClassify(flow *types.Flow) bool {
 	return checkFlowLayer(flow, layers.LayerTypeTCP, func(layer gopacket.Layer) bool {
 		payload := layer.LayerPayload()
 		return regex.Match(payload)
@@ -40,6 +40,6 @@ func (_ HTTPClassifier) HeuristicClassify(flow *godpi.Flow) bool {
 }
 
 // GetProtocol returns the corresponding protocol
-func (classifier HTTPClassifier) GetProtocol() godpi.Protocol {
-	return godpi.HTTP
+func (classifier HTTPClassifier) GetProtocol() types.Protocol {
+	return types.HTTP
 }

--- a/classifiers/icmp.go
+++ b/classifiers/icmp.go
@@ -3,14 +3,14 @@ package classifiers
 import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 )
 
 // ICMPClassifier struct
 type ICMPClassifier struct{}
 
 // HeuristicClassify for ICMPClassifier
-func (_ ICMPClassifier) HeuristicClassify(flow *godpi.Flow) bool {
+func (classifier ICMPClassifier) HeuristicClassify(flow *types.Flow) bool {
 	hasICMP4Packet := checkFlowLayer(flow, layers.LayerTypeIPv4, func(layer gopacket.Layer) bool {
 		ipLayer := layer.(*layers.IPv4)
 		return ipLayer.Protocol == layers.IPProtocolICMPv4
@@ -24,6 +24,6 @@ func (_ ICMPClassifier) HeuristicClassify(flow *godpi.Flow) bool {
 }
 
 // GetProtocol returns the corresponding protocol
-func (classifier ICMPClassifier) GetProtocol() godpi.Protocol {
-	return godpi.ICMP
+func (classifier ICMPClassifier) GetProtocol() types.Protocol {
+	return types.ICMP
 }

--- a/classifiers/netbios.go
+++ b/classifiers/netbios.go
@@ -2,14 +2,14 @@ package classifiers
 
 import (
 	"github.com/google/gopacket/layers"
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 )
 
 // NetBIOSClassifier struct
 type NetBIOSClassifier struct{}
 
 // HeuristicClassify for NetBIOSClassifier
-func (classifier NetBIOSClassifier) HeuristicClassify(flow *godpi.Flow) bool {
+func (classifier NetBIOSClassifier) HeuristicClassify(flow *types.Flow) bool {
 	if len(flow.Packets) == 0 {
 		return false
 	}
@@ -34,6 +34,6 @@ func (classifier NetBIOSClassifier) HeuristicClassify(flow *godpi.Flow) bool {
 }
 
 // GetProtocol returns the corresponding protocol
-func (classifier NetBIOSClassifier) GetProtocol() godpi.Protocol {
-	return godpi.NetBIOS
+func (classifier NetBIOSClassifier) GetProtocol() types.Protocol {
+	return types.NetBIOS
 }

--- a/classifiers/rdp.go
+++ b/classifiers/rdp.go
@@ -2,14 +2,14 @@ package classifiers
 
 import (
 	"github.com/google/gopacket/layers"
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 )
 
 // RDPClassifier struct
 type RDPClassifier struct{}
 
 // HeuristicClassify for RDPClassifier
-func (classifier RDPClassifier) HeuristicClassify(flow *godpi.Flow) bool {
+func (classifier RDPClassifier) HeuristicClassify(flow *types.Flow) bool {
 	if len(flow.Packets) == 0 {
 		return false
 	}
@@ -34,6 +34,6 @@ func (classifier RDPClassifier) HeuristicClassify(flow *godpi.Flow) bool {
 }
 
 // GetProtocol returns the corresponding protocol
-func (classifier RDPClassifier) GetProtocol() godpi.Protocol {
-	return godpi.RDP
+func (classifier RDPClassifier) GetProtocol() types.Protocol {
+	return types.RDP
 }

--- a/classifiers/rpc.go
+++ b/classifiers/rpc.go
@@ -2,14 +2,14 @@ package classifiers
 
 import (
 	"github.com/google/gopacket/layers"
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 )
 
 // RPCClassifier struct
 type RPCClassifier struct{}
 
 // HeuristicClassify for RPCClassifier
-func (classifier RPCClassifier) HeuristicClassify(flow *godpi.Flow) bool {
+func (classifier RPCClassifier) HeuristicClassify(flow *types.Flow) bool {
 	if len(flow.Packets) == 0 {
 		return false
 	}
@@ -28,6 +28,6 @@ func (classifier RPCClassifier) HeuristicClassify(flow *godpi.Flow) bool {
 }
 
 // GetProtocol returns the corresponding protocol
-func (classifier RPCClassifier) GetProtocol() godpi.Protocol {
-	return godpi.RPC
+func (classifier RPCClassifier) GetProtocol() types.Protocol {
+	return types.RPC
 }

--- a/classifiers/smb.go
+++ b/classifiers/smb.go
@@ -2,14 +2,14 @@ package classifiers
 
 import (
 	"github.com/google/gopacket/layers"
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 )
 
 // SMBClassifier struct
 type SMBClassifier struct{}
 
 // HeuristicClassify for SMBClassifier
-func (classifier SMBClassifier) HeuristicClassify(flow *godpi.Flow) bool {
+func (classifier SMBClassifier) HeuristicClassify(flow *types.Flow) bool {
 	if len(flow.Packets) == 0 {
 		return false
 	}
@@ -28,6 +28,6 @@ func (classifier SMBClassifier) HeuristicClassify(flow *godpi.Flow) bool {
 }
 
 // GetProtocol returns the corresponding protocol
-func (classifier SMBClassifier) GetProtocol() godpi.Protocol {
-	return godpi.SMB
+func (classifier SMBClassifier) GetProtocol() types.Protocol {
+	return types.SMB
 }

--- a/classifiers/smtp.go
+++ b/classifiers/smtp.go
@@ -3,7 +3,7 @@ package classifiers
 import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 	"strings"
 )
 
@@ -11,7 +11,7 @@ import (
 type SMTPClassifier struct{}
 
 // HeuristicClassify for SMTPClassifier
-func (classifier SMTPClassifier) HeuristicClassify(flow *godpi.Flow) bool {
+func (classifier SMTPClassifier) HeuristicClassify(flow *types.Flow) bool {
 	if len(flow.Packets) == 0 {
 		return false
 	}
@@ -34,6 +34,6 @@ func (classifier SMTPClassifier) HeuristicClassify(flow *godpi.Flow) bool {
 }
 
 // GetProtocol returns the corresponding protocol
-func (classifier SMTPClassifier) GetProtocol() godpi.Protocol {
-	return godpi.SMTP
+func (classifier SMTPClassifier) GetProtocol() types.Protocol {
+	return types.SMTP
 }

--- a/classifiers/ssh.go
+++ b/classifiers/ssh.go
@@ -3,7 +3,7 @@ package classifiers
 import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 	"strings"
 )
 
@@ -11,7 +11,7 @@ import (
 type SSHClassifier struct{}
 
 // HeuristicClassify for SSHClassifier
-func (_ SSHClassifier) HeuristicClassify(flow *godpi.Flow) bool {
+func (classifier SSHClassifier) HeuristicClassify(flow *types.Flow) bool {
 	return checkFirstPayload(flow.Packets, layers.LayerTypeTCP,
 		func(payload []byte, _ []*gopacket.Packet) bool {
 			payloadStr := string(payload)
@@ -22,6 +22,6 @@ func (_ SSHClassifier) HeuristicClassify(flow *godpi.Flow) bool {
 }
 
 // GetProtocol returns the corresponding protocol
-func (classifier SSHClassifier) GetProtocol() godpi.Protocol {
-	return godpi.SSH
+func (classifier SSHClassifier) GetProtocol() types.Protocol {
+	return types.SSH
 }

--- a/classifiers/ssl.go
+++ b/classifiers/ssl.go
@@ -4,14 +4,14 @@ import (
 	"encoding/binary"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 )
 
 // SSLClassifier struct
 type SSLClassifier struct{}
 
 // HeuristicClassify for SSLClassifier
-func (_ SSLClassifier) HeuristicClassify(flow *godpi.Flow) bool {
+func (classifier SSLClassifier) HeuristicClassify(flow *types.Flow) bool {
 	return checkFirstPayload(flow.Packets, layers.LayerTypeTCP,
 		func(payload []byte, _ []*gopacket.Packet) (detected bool) {
 			if len(payload) >= 9 {
@@ -29,6 +29,6 @@ func (_ SSLClassifier) HeuristicClassify(flow *godpi.Flow) bool {
 }
 
 // GetProtocol returns the corresponding protocol
-func (classifier SSLClassifier) GetProtocol() godpi.Protocol {
-	return godpi.SSL
+func (classifier SSLClassifier) GetProtocol() types.Protocol {
+	return types.SSL
 }

--- a/godpi.go
+++ b/godpi.go
@@ -1,0 +1,2 @@
+// Package godpi provides the main API interface for utilizing the go-dpi library.
+package godpi

--- a/godpi_example/example_app.go
+++ b/godpi_example/example_app.go
@@ -9,22 +9,23 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/pcap"
-	"github.com/mushorg/go-dpi"
 	"github.com/mushorg/go-dpi/classifiers"
+	"github.com/mushorg/go-dpi/types"
+	"github.com/mushorg/go-dpi/utils"
 	"github.com/mushorg/go-dpi/wrappers"
 )
 
 func main() {
 	var (
 		count, idCount int
-		protoCounts    map[godpi.Protocol]int
+		protoCounts    map[types.Protocol]int
 		packetChannel  <-chan gopacket.Packet
-		flow           *godpi.Flow
-		protocol       godpi.Protocol
+		flow           *types.Flow
+		protocol       types.Protocol
 		err            error
 	)
 
-	protoCounts = make(map[godpi.Protocol]int)
+	protoCounts = make(map[types.Protocol]int)
 	filename := flag.String("filename", "godpi_example/dumps/http.cap", "File to read packets from")
 	device := flag.String("device", "", "Device to watch for packets")
 
@@ -40,7 +41,7 @@ func main() {
 		packetChannel = gopacket.NewPacketSource(handle, handle.LinkType()).Packets()
 	} else if _, ferr := os.Stat(*filename); !os.IsNotExist(ferr) {
 		// check if file exists
-		packetChannel, err = godpi.ReadDumpFile(*filename)
+		packetChannel, err = utils.ReadDumpFile(*filename)
 	} else {
 		fmt.Println("File does not exist:", *filename)
 		return
@@ -67,9 +68,9 @@ func main() {
 	count = 0
 	for packet := range packetChannel {
 		fmt.Printf("Packet %d: ", count+1)
-		flow = godpi.CreateFlowFromPacket(&packet)
+		flow = types.CreateFlowFromPacket(&packet)
 		protocol, _ = classifiers.ClassifyFlow(flow)
-		if protocol != godpi.Unknown {
+		if protocol != types.Unknown {
 			fmt.Printf("Identified as %s\n", protocol)
 			idCount++
 			protoCounts[protocol]++
@@ -78,9 +79,9 @@ func main() {
 		}
 
 		wrapperProtocol, source := wrappers.ClassifyFlow(flow)
-		if wrapperProtocol != godpi.Unknown {
+		if wrapperProtocol != types.Unknown {
 			fmt.Printf("%s says %s\n", source, wrapperProtocol)
-			if protocol == godpi.Unknown {
+			if protocol == types.Unknown {
 				idCount++
 				protoCounts[wrapperProtocol]++
 			} else if protocol != wrapperProtocol {

--- a/types/flow.go
+++ b/types/flow.go
@@ -1,8 +1,9 @@
-package godpi
+// Package types contains the basic types used by the library.
+package types
 
 import "github.com/google/gopacket"
 
-var flowTracker map[gopacket.Flow]*Flow = make(map[gopacket.Flow]*Flow)
+var flowTracker = make(map[gopacket.Flow]*Flow)
 
 // ClassificationSource is the module of the library that is responsible for
 // the classification of a flow.

--- a/types/flow_test.go
+++ b/types/flow_test.go
@@ -1,10 +1,11 @@
-package godpi
+package types
 
 import (
 	"testing"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
+	"github.com/mushorg/go-dpi/utils"
 )
 
 func TestNewFlow(t *testing.T) {
@@ -24,7 +25,7 @@ func TestCreateFlowFromPacket(t *testing.T) {
 
 func TestGetFlowForPacket(t *testing.T) {
 	flows := make([]*Flow, 0)
-	dumpPackets, err := ReadDumpFile("godpi_example/dumps/http.cap")
+	dumpPackets, err := utils.ReadDumpFile("../godpi_example/dumps/http.cap")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +37,7 @@ func TestGetFlowForPacket(t *testing.T) {
 		}
 	}
 	if count := len(flows); count != 3 {
-		t.Fatal("Wrong number of flows detected: %d instead of 3", count)
+		t.Fatalf("Wrong number of flows detected: %d instead of 3", count)
 	}
 	packetCounts := [3]int{34, 2, 7}
 	for flowIdx, expectedCount := range packetCounts {
@@ -49,7 +50,7 @@ func TestGetFlowForPacket(t *testing.T) {
 func TestFlushTrackedFlows(t *testing.T) {
 	// make sure there are no flows left from other tests
 	FlushTrackedFlows()
-	dumpPackets, err := ReadDumpFile("godpi_example/dumps/http.cap")
+	dumpPackets, err := utils.ReadDumpFile("../godpi_example/dumps/http.cap")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/types/protocols.go
+++ b/types/protocols.go
@@ -1,9 +1,9 @@
-// Package godpi contains the basic types and methods that the library provides.
-package godpi
+package types
 
 // Protocol is the type of each of the detected protocols.
 type Protocol string
 
+// Protocol identifiers for the supported protocols
 const (
 	HTTP    Protocol = "HTTP"
 	DNS     Protocol = "DNS"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,4 +1,5 @@
-package godpi
+// Package utils provides some useful utility functions to the library.
+package utils
 
 import (
 	"github.com/google/gopacket"

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,4 +1,4 @@
-package godpi
+package utils
 
 import (
 	"github.com/google/gopacket/layers"
@@ -7,7 +7,7 @@ import (
 
 func TestReadDumpFile(t *testing.T) {
 	var count int
-	packets, err := ReadDumpFile("godpi_example/dumps/http.cap")
+	packets, err := ReadDumpFile("../godpi_example/dumps/http.cap")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wrappers/LPI_wrapper.go
+++ b/wrappers/LPI_wrapper.go
@@ -7,24 +7,24 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 )
 
 // lpiCodeToProtocol maps the LPI protocol codes to go-dpi protocols.
-var lpiCodeToProtocol = map[uint32]godpi.Protocol{
-	0:   godpi.HTTP,    // LPI_PROTO_HTTP
-	14:  godpi.DNS,     // LPI_PROTO_DNS
-	201: godpi.DNS,     // LPI_PROTO_UDP_DNS
-	8:   godpi.SSH,     // LPI_PROTO_SSH
-	23:  godpi.RPC,     // LPI_PROTO_RPC_SCAN
-	1:   godpi.SMTP,    // LPI_PROTO_SMTP
-	92:  godpi.SMTP,    // LPI_PROTO_INVALID_SMTP
-	21:  godpi.RDP,     // LPI_PROTO_RDP
-	24:  godpi.SMB,     // LPI_PROTO_SMB
-	380: godpi.ICMP,    // LPI_PROTO_ICMP
-	27:  godpi.FTP,     // LPI_PROTO_FTP_CONTROL
-	12:  godpi.SSL,     // LPI_PROTO_SSL
-	37:  godpi.NetBIOS, // LPI_PROTO_NETBIOS
+var lpiCodeToProtocol = map[uint32]types.Protocol{
+	0:   types.HTTP,    // LPI_PROTO_HTTP
+	14:  types.DNS,     // LPI_PROTO_DNS
+	201: types.DNS,     // LPI_PROTO_UDP_DNS
+	8:   types.SSH,     // LPI_PROTO_SSH
+	23:  types.RPC,     // LPI_PROTO_RPC_SCAN
+	1:   types.SMTP,    // LPI_PROTO_SMTP
+	92:  types.SMTP,    // LPI_PROTO_INVALID_SMTP
+	21:  types.RDP,     // LPI_PROTO_RDP
+	24:  types.SMB,     // LPI_PROTO_SMB
+	380: types.ICMP,    // LPI_PROTO_ICMP
+	27:  types.FTP,     // LPI_PROTO_FTP_CONTROL
+	12:  types.SSL,     // LPI_PROTO_SSL
+	37:  types.NetBIOS, // LPI_PROTO_NETBIOS
 }
 
 // LPIWrapperName is the identification of the libprotoident library.
@@ -53,7 +53,7 @@ func (wrapper *LPIWrapper) DestroyWrapper() error {
 
 // ClassifyFlow classifies a flow using the libprotoident library. It returns
 // the detected protocol and any error.
-func (wrapper *LPIWrapper) ClassifyFlow(flow *godpi.Flow) (godpi.Protocol, error) {
+func (wrapper *LPIWrapper) ClassifyFlow(flow *types.Flow) (types.Protocol, error) {
 	lpiFlow := C.lpiCreateFlow()
 	defer C.lpiFreeFlow(lpiFlow)
 	for _, packet := range flow.Packets {
@@ -65,11 +65,11 @@ func (wrapper *LPIWrapper) ClassifyFlow(flow *godpi.Flow) (godpi.Protocol, error
 	if proto, found := lpiCodeToProtocol[lpiProto]; found {
 		return proto, nil
 	}
-	return godpi.Unknown, nil
+	return types.Unknown, nil
 }
 
 // GetWrapperName returns the name of the wrapper, in order to identify which
 // wrapper provided a classification.
-func (wrapper *LPIWrapper) GetWrapperName() godpi.ClassificationSource {
+func (wrapper *LPIWrapper) GetWrapperName() types.ClassificationSource {
 	return LPIWrapperName
 }

--- a/wrappers/LPI_wrapper_test.go
+++ b/wrappers/LPI_wrapper_test.go
@@ -1,7 +1,8 @@
 package wrappers
 
 import (
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
+	"github.com/mushorg/go-dpi/utils"
 	"testing"
 )
 
@@ -10,25 +11,25 @@ func TestNDPIWrapperClassifyFlow(t *testing.T) {
 	wrapper.InitializeWrapper()
 	defer wrapper.DestroyWrapper()
 
-	packetChan, _ := godpi.ReadDumpFile("../godpi_example/dumps/http.cap")
+	packetChan, _ := utils.ReadDumpFile("../godpi_example/dumps/http.cap")
 
-	flow := godpi.NewFlow()
+	flow := types.NewFlow()
 	for i := 0; i < 3; i++ {
 		packet := <-packetChan
 		flow.Packets = append(flow.Packets, &packet)
 	}
 
 	// first three packets should not be enough to classify the flow
-	if result, _ := wrapper.ClassifyFlow(flow); result != godpi.Unknown {
+	if result, _ := wrapper.ClassifyFlow(flow); result != types.Unknown {
 		t.Errorf("Incorrectly detected %s instead of Unknown", result)
 	}
 
-	flow = godpi.NewFlow()
+	flow = types.NewFlow()
 	packet := <-packetChan
 	flow.Packets = append(flow.Packets, &packet)
 
 	// fourth packet should be HTTP
-	if result, _ := wrapper.ClassifyFlow(flow); result != godpi.HTTP {
+	if result, _ := wrapper.ClassifyFlow(flow); result != types.HTTP {
 		t.Errorf("Incorrectly detected %s instead of HTTP", result)
 	}
 }

--- a/wrappers/nDPI_wrapper.go
+++ b/wrappers/nDPI_wrapper.go
@@ -7,24 +7,24 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 	"github.com/pkg/errors"
 )
 
 // ndpiCodeToProtocol maps the nDPI protocol codes to go-dpi protocols.
-var ndpiCodeToProtocol = map[uint32]godpi.Protocol{
-	7:   godpi.HTTP,    // NDPI_PROTOCOL_HTTP
-	5:   godpi.DNS,     // NDPI_PROTOCOL_DNS
-	92:  godpi.SSH,     // NDPI_PROTOCOL_SSH
-	127: godpi.RPC,     // NDPI_PROTOCOL_DCERPC
-	3:   godpi.SMTP,    // NDPI_PROTOCOL_MAIL_SMTP
-	88:  godpi.RDP,     // NDPI_PROTOCOL_RDP
-	16:  godpi.SMB,     // NDPI_PROTOCOL_SMB
-	81:  godpi.ICMP,    // NDPI_PROTOCOL_IP_ICMP
-	1:   godpi.FTP,     // NDPI_PROTOCOL_FTP_CONTROL
-	91:  godpi.SSL,     // NDPI_PROTOCOL_SSL
-	64:  godpi.SSL,     // NDPI_PROTOCOL_SSL_NO_CERT
-	10:  godpi.NetBIOS, // NDPI_PROTOCOL_NETBIOS
+var ndpiCodeToProtocol = map[uint32]types.Protocol{
+	7:   types.HTTP,    // NDPI_PROTOCOL_HTTP
+	5:   types.DNS,     // NDPI_PROTOCOL_DNS
+	92:  types.SSH,     // NDPI_PROTOCOL_SSH
+	127: types.RPC,     // NDPI_PROTOCOL_DCERPC
+	3:   types.SMTP,    // NDPI_PROTOCOL_MAIL_SMTP
+	88:  types.RDP,     // NDPI_PROTOCOL_RDP
+	16:  types.SMB,     // NDPI_PROTOCOL_SMB
+	81:  types.ICMP,    // NDPI_PROTOCOL_IP_ICMP
+	1:   types.FTP,     // NDPI_PROTOCOL_FTP_CONTROL
+	91:  types.SSL,     // NDPI_PROTOCOL_SSL
+	64:  types.SSL,     // NDPI_PROTOCOL_SSL_NO_CERT
+	10:  types.NetBIOS, // NDPI_PROTOCOL_NETBIOS
 }
 
 // NDPIWrapperName is the identification of the nDPI library.
@@ -80,7 +80,7 @@ func (wrapper *NDPIWrapper) DestroyWrapper() error {
 
 // ClassifyFlow classifies a flow using the nDPI library. It returns the
 // detected protocol and any error.
-func (wrapper *NDPIWrapper) ClassifyFlow(flow *godpi.Flow) (godpi.Protocol, error) {
+func (wrapper *NDPIWrapper) ClassifyFlow(flow *types.Flow) (types.Protocol, error) {
 	for _, ppacket := range flow.Packets {
 		packet := *ppacket
 		seconds := packet.Metadata().Timestamp.Second()
@@ -93,21 +93,21 @@ func (wrapper *NDPIWrapper) ClassifyFlow(flow *godpi.Flow) (godpi.Protocol, erro
 		} else if ndpiProto < 0 {
 			switch ndpiProto {
 			case -10:
-				return godpi.Unknown, errors.New("nDPI wrapper does not support IPv6")
+				return types.Unknown, errors.New("nDPI wrapper does not support IPv6")
 			case -11:
-				return godpi.Unknown, errors.New("Received fragmented packet")
+				return types.Unknown, errors.New("Received fragmented packet")
 			case -12:
-				return godpi.Unknown, errors.New("Error creating nDPI flow")
+				return types.Unknown, errors.New("Error creating nDPI flow")
 			default:
-				return godpi.Unknown, errors.New("nDPI unknown error")
+				return types.Unknown, errors.New("nDPI unknown error")
 			}
 		}
 	}
-	return godpi.Unknown, nil
+	return types.Unknown, nil
 }
 
 // GetWrapperName returns the name of the wrapper, in order to identify which
 // wrapper provided a classification.
-func (wrapper *NDPIWrapper) GetWrapperName() godpi.ClassificationSource {
+func (wrapper *NDPIWrapper) GetWrapperName() types.ClassificationSource {
 	return NDPIWrapperName
 }

--- a/wrappers/nDPI_wrapper_test.go
+++ b/wrappers/nDPI_wrapper_test.go
@@ -4,7 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
+	"github.com/mushorg/go-dpi/utils"
 )
 
 func TestNewNDPIWrapper(t *testing.T) {
@@ -14,8 +15,8 @@ func TestNewNDPIWrapper(t *testing.T) {
 }
 
 func TestNDPIWrapperClassification(t *testing.T) {
-	flow := godpi.NewFlow()
-	packetChan, _ := godpi.ReadDumpFile("../godpi_example/dumps/http.cap")
+	flow := types.NewFlow()
+	packetChan, _ := utils.ReadDumpFile("../godpi_example/dumps/http.cap")
 	for i := 0; i < 4; i++ {
 		packet := <-packetChan
 		flow.Packets = append(flow.Packets, &packet)
@@ -26,7 +27,7 @@ func TestNDPIWrapperClassification(t *testing.T) {
 	result, err := wrapper.ClassifyFlow(flow)
 	wrapper.DestroyWrapper()
 
-	if result != godpi.HTTP || err != nil {
+	if result != types.HTTP || err != nil {
 		t.Errorf("Incorrectly detected flow protocol: %s instead of HTTP", result)
 	}
 }
@@ -80,12 +81,12 @@ func TestNDPIWrapper_ClassifyFlowErrors(t *testing.T) {
 	}
 
 	// empty flow should be unknown
-	if ret, _ := wrapper.ClassifyFlow(godpi.NewFlow()); ret != godpi.Unknown {
+	if ret, _ := wrapper.ClassifyFlow(types.NewFlow()); ret != types.Unknown {
 		t.Errorf("Incorrectly classified empty flow: %s instead of unknown", ret)
 	}
 
-	flow := godpi.NewFlow()
-	packetChan, _ := godpi.ReadDumpFile("../godpi_example/dumps/http.cap")
+	flow := types.NewFlow()
+	packetChan, _ := utils.ReadDumpFile("../godpi_example/dumps/http.cap")
 	packet := <-packetChan
 	flow.Packets = append(flow.Packets, &packet)
 

--- a/wrappers/wrappers.go
+++ b/wrappers/wrappers.go
@@ -5,7 +5,7 @@ package wrappers
 import (
 	"fmt"
 
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 	"os"
 )
 
@@ -14,8 +14,8 @@ import (
 type Wrapper interface {
 	InitializeWrapper() error
 	DestroyWrapper() error
-	ClassifyFlow(*godpi.Flow) (godpi.Protocol, error)
-	GetWrapperName() godpi.ClassificationSource
+	ClassifyFlow(*types.Flow) (types.Protocol, error)
+	GetWrapperName() types.ClassificationSource
 }
 
 var wrapperList = []Wrapper{
@@ -48,9 +48,9 @@ func DestroyWrappers() {
 
 // ClassifyFlow applies all the wrappers to a flow and returns the protocol
 // that is detected by a wrapper if there is one. Otherwise, it returns nil.
-func ClassifyFlow(flow *godpi.Flow) (result godpi.Protocol, source godpi.ClassificationSource) {
+func ClassifyFlow(flow *types.Flow) (result types.Protocol, source types.ClassificationSource) {
 	for _, wrapper := range activeWrappers {
-		if proto, err := wrapper.ClassifyFlow(flow); proto != godpi.Unknown && err == nil {
+		if proto, err := wrapper.ClassifyFlow(flow); proto != types.Unknown && err == nil {
 			result = proto
 			source = wrapper.GetWrapperName()
 			flow.DetectedProtocol = proto

--- a/wrappers/wrappers_test.go
+++ b/wrappers/wrappers_test.go
@@ -3,7 +3,7 @@ package wrappers
 import (
 	"testing"
 
-	"github.com/mushorg/go-dpi"
+	"github.com/mushorg/go-dpi/types"
 	"github.com/pkg/errors"
 )
 
@@ -27,17 +27,17 @@ func (wrapper *MockWrapper) DestroyWrapper() error {
 	return nil
 }
 
-func (wrapper *MockWrapper) ClassifyFlow(flow *godpi.Flow) (godpi.Protocol, error) {
+func (wrapper *MockWrapper) ClassifyFlow(flow *types.Flow) (types.Protocol, error) {
 	wrapper.classifyCalled = true
-	return godpi.HTTP, nil
+	return types.HTTP, nil
 }
 
-func (wrapper *MockWrapper) GetWrapperName() godpi.ClassificationSource {
+func (wrapper *MockWrapper) GetWrapperName() types.ClassificationSource {
 	return "mock"
 }
 
 func TestClassifyFlowUninitialized(t *testing.T) {
-	flow := godpi.NewFlow()
+	flow := types.NewFlow()
 	uninitialized := &MockWrapper{initializeSuccessfully: false}
 	wrapperList = []Wrapper{
 		uninitialized,
@@ -50,10 +50,10 @@ func TestClassifyFlowUninitialized(t *testing.T) {
 	if uninitialized.classifyCalled {
 		t.Error("Classify called on uninitialized wrapper")
 	}
-	if result != godpi.Unknown {
+	if result != types.Unknown {
 		t.Error("Empty classify did not return unknown")
 	}
-	if source != godpi.NoSource {
+	if source != types.NoSource {
 		t.Error("Empty classify incorrectly returned source")
 	}
 	DestroyWrappers()
@@ -63,7 +63,7 @@ func TestClassifyFlowUninitialized(t *testing.T) {
 }
 
 func TestClassifyFlowInitialized(t *testing.T) {
-	flow := godpi.NewFlow()
+	flow := types.NewFlow()
 	initialized := &MockWrapper{initializeSuccessfully: true}
 	wrapperList = []Wrapper{
 		initialized,
@@ -76,7 +76,7 @@ func TestClassifyFlowInitialized(t *testing.T) {
 	if !initialized.classifyCalled {
 		t.Error("Classify not called on active wrapper")
 	}
-	if result != godpi.HTTP || flow.DetectedProtocol != godpi.HTTP {
+	if result != types.HTTP || flow.DetectedProtocol != types.HTTP {
 		t.Error("Classify did not return correct result")
 	}
 	if source != "mock" || flow.ClassificationSource != "mock" {


### PR DESCRIPTION
* Move types and utils into new packages for better project structure
  and to avoid circular dependencies. (closes #27)

Signed-off-by: Nikos Filippakis <aesmade@gmail.com>